### PR TITLE
Fix magic link confirmation running on GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,22 +78,25 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 
 The project uses **Prisma** as the ORM. Follow these steps to set up your PostgreSQL database:
 
-1. **Initialize Migration**: Create the database tables based on the schema.
-   ```bash
-   npx prisma migrate dev --name init
-   ```
+### Option A: Cloud Setup using Neon.tech (Recommended for Production)
 
-2. **Generate Client**: Ensure the Prisma Client is up to date.
-   ```bash
-   npx prisma generate
-   ```
+1.  **Sign Up**: Create a free account at [Neon.tech](https://neon.tech/).
+2.  **Create Project**: Create a new project and database instance.
+3.  **Get Connection String**: 
+    - In the Neon console, go to the **Dashboard**.
+    - Copy the **Connection Details** (ensure it's the `Connection String` format).
+    - It should look like: `postgresql://[user]:[password]@[neon-host]/[dbname]?sslmode=require`.
+4.  **Configure `.env`**:
+    - Paste the connection string into your `.env` file:
+      ```env
+      DATABASE_URL="postgresql://user:password@ep-shiny-glade-123456.us-east-2.aws.neon.tech/neondb?sslmode=require"
+      ```
+5.  **Initialize Database**:
+    ```bash
+    npx prisma migrate dev --name init
+    ```
 
-3. **Database GUI** (Optional): View your data in a browser.
-   ```bash
-   npx prisma studio
-   ```
-
-### Option B: Local Setup using Docker (Recommended)
+### Option B: Local Setup using Docker (Recommended for Development)
 
 If you want to run the database locally without setting up a cloud provider:
 

--- a/app/confirm/AutoConfirm.tsx
+++ b/app/confirm/AutoConfirm.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Center, Card, Stack, Text, Loader } from "@mantine/core";
+import SuccessUI from "./SuccessUI";
+import { Submission } from "@prisma/client";
+
+interface AutoConfirmProps {
+  token: string;
+  submission: Submission;
+}
+
+function AutoConfirm({ token, submission }: AutoConfirmProps) {
+  const [done, setDone] = useState(false);
+  const [alreadyVerified, setAlreadyVerified] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/confirm", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        console.log("Confirmation result:", data);
+        if (data.status === "ALREADY_CONFIRMED") {
+          setAlreadyVerified(true);
+        }
+        setDone(true);
+      });
+  }, [token]);
+
+  if (!done) {
+    return (
+      <Center h="100vh" px="md">
+        <Card shadow="md" radius="md" p="xl" maw={420} w="100%">
+          <Stack align="center" gap="md">
+            <Loader size="lg" />
+            <Text c="dimmed">Confirming your submission…</Text>
+          </Stack>
+        </Card>
+      </Center>
+    );
+  }
+
+  return <SuccessUI submission={submission} alreadyVerified={alreadyVerified} />;
+}
+
+export default AutoConfirm;

--- a/app/confirm/SuccessUI.tsx
+++ b/app/confirm/SuccessUI.tsx
@@ -1,0 +1,51 @@
+import { Center, Card, Stack, ThemeIcon, Title, Text, Button } from "@mantine/core";
+import { IconCircleCheck } from "@tabler/icons-react";
+import Link from "next/link";
+import { Submission } from "@prisma/client";
+
+function SuccessUI({
+  submission,
+  alreadyVerified = false,
+}: {
+  submission: Submission;
+  alreadyVerified?: boolean;
+}) {
+  return (
+    <Center h="100vh" px="md">
+      <Card shadow="md" radius="md" p="xl" maw={480} w="100%">
+        <Stack align="center">
+          <ThemeIcon color="green" size={64} radius="xl">
+            <IconCircleCheck size={36} />
+          </ThemeIcon>
+
+          <Title order={2}>
+            {alreadyVerified ? "Link already verified" : "Submission confirmed"}
+          </Title>
+
+          <Text ta="center">
+            Thank you, <strong>{submission.name}</strong>. Your email has been
+            verified successfully.
+          </Text>
+          <Text ta="center">
+            Company: <strong>{submission.companyName}</strong>
+          </Text>
+          <Text ta="center">
+            LinkedIn: <strong>{submission.linkedinUrl}</strong>
+          </Text>
+          {submission.documentName && (
+            <Text size="sm" c="dimmed">
+              Document: <strong>{submission.documentName}</strong>
+            </Text>
+          )}
+
+          <Link href="/submission">
+            <Button mt="lg" variant="light">
+              Submit another response
+            </Button>
+          </Link>
+        </Stack>
+      </Card>
+    </Center>
+  );
+}
+export default SuccessUI;

--- a/app/confirm/page.tsx
+++ b/app/confirm/page.tsx
@@ -1,11 +1,13 @@
 import { prisma } from "@/lib/prisma";
 import { hashToken } from "@/lib/token";
-import {Center, Card, Title, Text, Stack, Button, ThemeIcon} from "@mantine/core";
-import { IconCircleCheck, IconAlertTriangle } from "@tabler/icons-react";
+import { Center, Card, Title, Text, Stack, Button, ThemeIcon } from "@mantine/core";
+import { IconAlertTriangle } from "@tabler/icons-react";
 import Link from "next/link";
+import SuccessUI from "./SuccessUI";
+import AutoConfirm from "./AutoConfirm";
 
 interface PageProps {
-  searchParams: Promise<{ token?: string }>;
+  searchParams: Promise<{ token: string }>;
 }
 
 export default async function ConfirmPage({ searchParams }: PageProps) {
@@ -41,11 +43,7 @@ export default async function ConfirmPage({ searchParams }: PageProps) {
     include: { submission: true },
   });
 
-  if (
-    !magicLinkToken ||
-    magicLinkToken.usedAt ||
-    magicLinkToken.expiresAt < new Date()
-  ) {
+  if (!magicLinkToken || magicLinkToken.expiresAt < new Date()) {
     return (
       <Center h="100vh" px="md">
         <Card shadow="md" radius="md" p="xl" maw={420} w="100%">
@@ -56,7 +54,7 @@ export default async function ConfirmPage({ searchParams }: PageProps) {
 
             <Title order={3}>Link expired</Title>
             <Text c="dimmed" ta="center">
-              This magic link has already been used or expired.
+              This magic link is invalid or has expired.
             </Text>
 
             <Link href="/submission">
@@ -68,54 +66,13 @@ export default async function ConfirmPage({ searchParams }: PageProps) {
     );
   }
 
-  await prisma.$transaction([
-    prisma.magicLinkToken.update({
-      where: { id: magicLinkToken.id },
-      data: { usedAt: new Date() },
-    }),
-    prisma.submission.update({
-      where: { id: magicLinkToken.submission.id },
-      data: { status: "CONFIRMED" },
-    }),
-  ]);
+  // If the token has already been used, show the success UI
+  if (magicLinkToken.usedAt) {
+    return <SuccessUI submission={magicLinkToken.submission} alreadyVerified={true} />;
+  }
 
-  return (
-    <Center h="100vh" px="md">
-      <Card shadow="md" radius="md" p="xl" maw={480} w="100%">
-        <Stack align="center">
-          <ThemeIcon color="green" size={64} radius="xl">
-            <IconCircleCheck size={36} />
-          </ThemeIcon>
 
-          <Title order={2}>Submission confirmed</Title>
-
-          <Text ta="center">
-            Thank you,{" "}
-            <strong>{magicLinkToken.submission.name}</strong>. Your email has
-            been verified successfully.
-          </Text>
-          <Text ta="center"> 
-            Company:{" "}
-            <strong>{magicLinkToken.submission.companyName}</strong>
-          </Text>
-          <Text ta="center">
-            LinkedIn:{" "}
-            <strong>{magicLinkToken.submission.linkedinUrl}</strong>
-          </Text>
-          {magicLinkToken.submission.documentName && (
-            <Text size="sm" c="dimmed">
-              Document:{" "}
-              <strong>{magicLinkToken.submission.documentName}</strong>
-            </Text>
-          )}
-
-          <Link href="/submission">
-            <Button mt="lg" variant="light">
-              Submit another response
-            </Button>
-          </Link>
-        </Stack>
-      </Card>
-    </Center>
-  );
+  // Token is valid and NOT used yet - Render AutoConfirm component to handle confirmation via API
+  return <AutoConfirm token={token} submission={magicLinkToken.submission} />;
 }
+


### PR DESCRIPTION
### Problem
Confirmation logic was running in a Server Component (GET request) and mutating DB.
Email clients prefetch links via GET, which consumed tokens before users clicked.

### Fix
- Server Component is now read-only (no DB mutation)
- Token consumption moved to POST `/api/confirm`
- Client triggers POST after page load

### Result
- Email previews no longer invalidate magic links
- Follows correct HTTP semantics
